### PR TITLE
Migrate auth from client_id/secret to access_key

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -6,5 +6,4 @@ NEXT_PUBLIC_EDITABLE=false
 
 # StatelyDB (get these from Stately Cloud)
 STATELY_STORE_ID=your_store_id
-STATELY_CLIENT_ID=your_client_id
-STATELY_CLIENT_SECRET=your_client_secret
+STATELY_ACCESS_KEY=your_access_key

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2FStatelyCloud%2Fvercel-starter-template&env=STATELY_STORE_ID,STATELY_CLIENT_SECRET,STATELY_CLIENT_SECRET,PROFILE_SLUG,NEXT_PUBLIC_EDITABLE&envDescription=API%20keys%20and%20Store%20configuration.&envLink=https%3A%2F%2Fdocs.stately.cloud%2Fguides%2Fconnect%2F&skippable-integrations=1)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2FStatelyCloud%2Fvercel-starter-template&env=STATELY_STORE_ID,STATELY_ACCESS_KEY,PROFILE_SLUG,NEXT_PUBLIC_EDITABLE&envDescription=API%20keys%20and%20Store%20configuration.&envLink=https%3A%2F%2Fdocs.stately.cloud%2Fguides%2Fconnect%2F&skippable-integrations=1)
 
 # Vercel Starter Template
 
@@ -40,8 +40,7 @@ This is a sample NextJS webapp that uses StatelyDB.
    vercel env add NEXT_PUBLIC_EDITABLE
    vercel env add PROFILE_SLUG
    vercel env add STATELY_STORE_ID
-   vercel env add STATELY_CLIENT_ID
-   vercel env add STATELY_CLIENT_SECRET
+   vercel env add STATELY_ACCESS_KEY
    ```
 
    See `.env.local.example` for example values.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "vercel-starter-template",
       "version": "0.1.0",
       "dependencies": {
-        "@stately-cloud/client": "^0.12.0",
+        "@stately-cloud/client": "^0.17.1",
         "@stately-cloud/schema": "^0.10.0",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
@@ -48,25 +48,23 @@
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@connectrpc/connect": {
-      "version": "2.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.0.0-rc.3.tgz",
-      "integrity": "sha512-ARBt64yEyKbanyRETTjcjJuHr2YXorzQo0etyS5+P6oSeW8xEuzajA9g+zDnMcj1hlX2dQE93foIWQGfpru7gQ==",
-      "license": "Apache-2.0",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.0.0.tgz",
+      "integrity": "sha512-Usm8jgaaULANJU8vVnhWssSA6nrZ4DJEAbkNtXSoZay2YD5fDyMukCxu8NEhCvFzfHvrhxhcjttvgpyhOM7xAQ==",
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.2.0"
       }
     },
     "node_modules/@connectrpc/connect-node": {
-      "version": "2.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@connectrpc/connect-node/-/connect-node-2.0.0-rc.3.tgz",
-      "integrity": "sha512-lJEuqkpCfkELX0G8HFClLxh+3/lbwAC8EylXMTCL1+XUTwLXYc4DFORTmqCNObp723fW2mPlGDOpWy5t9m/fYg==",
-      "license": "Apache-2.0",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-node/-/connect-node-2.0.0.tgz",
+      "integrity": "sha512-DoI5T+SUvlS/8QBsxt2iDoUg15dSxqhckegrgZpWOtADtmGohBIVbx1UjtWmjLBrP4RdD0FeBw+XyRUSbpKnJQ==",
       "engines": {
         "node": ">=18.14.1"
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.2.0",
-        "@connectrpc/connect": "2.0.0-rc.3"
+        "@connectrpc/connect": "2.0.0"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -1231,14 +1229,13 @@
       "license": "MIT"
     },
     "node_modules/@stately-cloud/client": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@stately-cloud/client/-/client-0.12.0.tgz",
-      "integrity": "sha512-Sp4uwTVm5S5a+RBhvpc2cLfyzexLnreTuRUZJOrmEYXGB9fZ6fj/5eE1AP2+4tfByo+ImmlY8igy9QWMvLmxCw==",
-      "license": "Apache-2.0",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@stately-cloud/client/-/client-0.17.1.tgz",
+      "integrity": "sha512-R6P99w1DxNUSztuSMVyvKxnnGeWNcaAyp9+oC0n/sLl8G+zTmT564QBsPHJDHLvrfQVjkTRQqovtdqVcgflXkg==",
       "dependencies": {
         "@bufbuild/protobuf": "^2.2.0",
-        "@connectrpc/connect": "^2.0.0-rc.1",
-        "@connectrpc/connect-node": "^2.0.0-rc.1"
+        "@connectrpc/connect": "^2.0.0",
+        "@connectrpc/connect-node": "^2.0.0"
       },
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@stately-cloud/client": "^0.12.0",
+    "@stately-cloud/client": "^0.17.1",
     "@stately-cloud/schema": "^0.10.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",

--- a/src/lib/stately.ts
+++ b/src/lib/stately.ts
@@ -1,10 +1,7 @@
 import { createClient } from "./generated/index.js";
 
-if (!process.env.STATELY_CLIENT_ID) {
-  throw new Error("Missing STATELY_CLIENT_ID");
-}
-if (!process.env.STATELY_CLIENT_SECRET) {
-  throw new Error("Missing STATELY_CLIENT_SECRET");
+if (!process.env.STATELY_ACCESS_KEY) {
+  throw new Error("Missing STATELY_ACCESS_KEY");
 }
 if (!process.env.STATELY_STORE_ID) {
   throw new Error("Missing STATELY_STORE_ID");


### PR DESCRIPTION
## Background
- Now that we've implemented our new and improved access key auth we want to migrate customers over to using access_key so we can remove support for client_id/secret

## Changes
- Swap auth from client_id/secret to access_key

## Testing
- [x] Linter passes